### PR TITLE
Revert "sched/fair: Fix CFS bandwidth control lockdep DEADLOCK report"

### DIFF
--- a/kernel/sched/fair.c
+++ b/kernel/sched/fair.c
@@ -4629,9 +4629,9 @@ void init_cfs_bandwidth(struct cfs_bandwidth *cfs_b)
 	cfs_b->period = ns_to_ktime(default_cfs_period());
 
 	INIT_LIST_HEAD(&cfs_b->throttled_cfs_rq);
-	hrtimer_init(&cfs_b->period_timer, CLOCK_MONOTONIC, HRTIMER_MODE_ABS_PINNED_HARD);
+	hrtimer_init(&cfs_b->period_timer, CLOCK_MONOTONIC, HRTIMER_MODE_ABS_PINNED);
 	cfs_b->period_timer.function = sched_cfs_period_timer;
-	hrtimer_init(&cfs_b->slack_timer, CLOCK_MONOTONIC, HRTIMER_MODE_REL_HARD);
+	hrtimer_init(&cfs_b->slack_timer, CLOCK_MONOTONIC, HRTIMER_MODE_REL);
 	cfs_b->slack_timer.function = sched_cfs_slack_timer;
 	cfs_b->distribute_running = 0;
 }


### PR DESCRIPTION
HRTIMER_MODE_ABS_PINNED_HARD and HRTIMER_MODE_REL_HARD require additional work. But as this bug is related only to rt kernel revert this commit is enough for us

This reverts commit c848d6954914b80f31c96ac82e7b1e73a97772ae.