### PR TITLE
zstd: disable debugging

### DIFF
--- a/lib/zstd/Makefile
+++ b/lib/zstd/Makefile
@@ -39,8 +39,9 @@ zstd_decompress-y := \
 
 zstd_common-y := \
 		zstd_common_module.o \
-		common/debug.o \
 		common/entropy_common.o \
 		common/error_private.o \
 		common/fse_decompress.o \
 		common/zstd_common.o
+
+obj-$(CONFIG_DEBUG_KERNEL) += common/debug.o


### PR DESCRIPTION
Will be enabled only when CONFIG_DEBUG_KERNEL is set